### PR TITLE
Add DfPlayerMini library abstraction layer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         export PLATFORMIO_BUILD_DIR=$HOME/build-carl
         make -C carl ci
         mkdir -p firmware
-        cp $PLATFORMIO_BUILD_DIR/pro16MHzatmega328/firmware.hex firmware/
+        cp $PLATFORMIO_BUILD_DIR/pro16MHzatmega328-makuna/firmware.hex firmware/
 
     - name: upload carl artifacts
       uses: actions/upload-artifact@master

--- a/carl/.clang-format
+++ b/carl/.clang-format
@@ -1,0 +1,96 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -3
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/carl/Makefile
+++ b/carl/Makefile
@@ -16,8 +16,14 @@ ci: phony
 clean: phony
 	pio run --target clean
 
-upload: phony
-	pio run --target upload
+upload-makuna: phony
+	pio run --target upload --environment pro16MHzatmega328-makuna
+
+upload-dfrobot: phony
+	pio run --target upload --environment pro16MHzatmega328-dfrobot
+
+upload-powerbroker: phony
+	pio run --target upload --environment pro16MHzatmega328-powerbroker
 
 monitor: phony
 	pio device monitor 

--- a/carl/carl.h
+++ b/carl/carl.h
@@ -19,9 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
-#ifndef CARL_H_
-#define CARL_H_
-
+#pragma once
 #include <Arduino.h>
 
 // Hardware configuration - where stuff is connected / Konfiguration der
@@ -33,5 +31,3 @@ constexpr uint8_t PIN_RX = 9;
 constexpr uint8_t PIN_TX = 8;
 constexpr uint8_t PIN_LED = 10;
 constexpr uint8_t PIN_DFPLAYER_BUSY = 12;
-
-#endif  // CARL_H_

--- a/carl/carl.ino
+++ b/carl/carl.ino
@@ -23,12 +23,14 @@
 #include <SoftwareSerial.h>
 #include <jled.h>
 
-#include "log.h"        // NOLINT
-#include "carl.h"    // NOLINT
-#include "keypad.h"     // NOLINT
-#include "mp3module.h"  // NOLINT
-#include "player.h"     // NOLINT
-#include "volume.h"     // NOLINT
+#include "log.h"                      // NOLINT
+#include "carl.h"                     // NOLINT
+#include "keypad.h"                   // NOLINT
+#include "mp3_driver.h"               // NOLINT
+#include "mp3_driver_factory.h"
+#include "mp3module.h"                // NOLINT
+#include "player.h"                   // NOLINT
+#include "volume.h"                   // NOLINT
 
 Player* player_;
 
@@ -36,25 +38,25 @@ Player* player_;
  * startup: initialize serial port and player, play greeting jingle.
  */
 void setup() {
-  Serial.begin(9600);
-  LOG_INIT(&Serial);
-  LOG("carl starting");
+    Serial.begin(9600);
+    LOG_INIT(&Serial);
+    LOG("carl starting.");
 
-  // Wire the components of the player
+    // Wire the components of the player
 
-  // DFPlayerMini module and Arduino communicate through software serial iface
-  auto mp3serial = new SoftwareSerial(PIN_RX, PIN_TX);
-  auto mp3module = new Mp3Module(mp3serial, PIN_DFPLAYER_BUSY,
-                                 Mp3Module::ePlayMode::REPEAT);
-  auto status_led = new JLed(PIN_LED);
-  status_led->LowActive();
-  auto buttons = new Keypad(PIN_BUTTONS);
-  auto volume_knob = new VolumeKnob(PIN_VOLUME, PIN_VOLUME_POWER);
-  player_ = new Player(mp3module, buttons, volume_knob, status_led);
+    // DFPlayerMini module and Arduino communicate through software serial iface
+    auto mp3serial = new SoftwareSerial(PIN_RX, PIN_TX);
+    auto mp3driver = new_mp3_driver(mp3serial, PIN_DFPLAYER_BUSY);
+    auto mp3module = new Mp3Module(mp3driver, Mp3Module::ePlayMode::REPEAT);
+    auto status_led = new JLed(PIN_LED);
+    status_led->LowActive();
+    auto buttons = new Keypad(PIN_BUTTONS);
+    auto volume_knob = new VolumeKnob(PIN_VOLUME, PIN_VOLUME_POWER);
+    player_ = new Player(mp3module, buttons, volume_knob, status_led);
 
-  for (auto i = 0; i < 100; i++) {
-    randomSeed(analogRead(0));
-  }
+    for (auto i = 0; i < 100; i++) {
+        randomSeed(analogRead(0));
+    }
 }
 
 void loop() { player_->update(); }

--- a/carl/keypad.h
+++ b/carl/keypad.h
@@ -19,9 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
-#ifndef KEYPAD_H_
-#define KEYPAD_H_
-
+#pragma once
 #include <AnalogMultiButton.h>
 
 // Mapping of logical keycode to values returned by AnalogMutliButton
@@ -81,5 +79,3 @@ class Keypad {
 
   AnalogMultiButton buttons_;
 };
-
-#endif  //  KEYPAD_H_

--- a/carl/log.h
+++ b/carl/log.h
@@ -19,11 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
-#ifndef LOG_H_
-#define LOG_H_
-
+#pragma once
 #ifndef NO_LOGGING
 #define ENABLE_LOG4ARDUINO  // comment out to disable logging
 #endif
 #include <log4arduino.h>
-#endif  // LOG_H_

--- a/carl/mp3_driver.h
+++ b/carl/mp3_driver.h
@@ -20,21 +20,32 @@
 // IN THE SOFTWARE.
 //
 #pragma once
-#include <Arduino.h>
+#include <stdint.h>
 
-class VolumeKnob {
+// abstracts the actual mp3 hardware used so that we can use different
+// libraries or modules without changing application code.
+class Mp3Driver {
  public:
-  VolumeKnob() = delete;
-  explicit VolumeKnob(uint8_t pin_poti, uint8_t pin_power);
-
-  // reads volume and returns value in range [0..volume_max]
-  uint16_t readVolume(uint16_t volume_max);
-
- private:
-  static constexpr float kAlpha = 0.6;
-  static constexpr auto kSampleTimeMs = 100;
-  uint16_t last_reading_ = 0;
-  uint8_t pin_poti_;
-  uint8_t pin_power_;
-  uint32_t time_last_ = 0;
+    // start playback
+    virtual void start() = 0;
+    // pause playback
+    virtual void pause() = 0;
+    // stop playback
+    virtual void stop() = 0;
+    // play song from given folder.
+    virtual void playSongFromFolder(uint8_t folder, uint16_t song) = 0;
+    // return maximum allowed volume
+    virtual uint8_t getMaxVolume() const = 0;
+    // set volume. volume is in range [0..getMaxVolume()]
+    virtual void setVolume(uint8_t vol) = 0;
+    // set the equalizer mode. mode is in range [0..getNumEqModes()-1]
+    virtual void setEqMode(uint8_t mode) = 0;
+    // return numer of equalizer modes
+    virtual uint8_t getNumEqModes() const = 0;
+    // returns number of files found in the given folder. -1 if none or error
+    virtual int16_t getFileCountInFolder(uint8_t folder) = 0;
+    // return true if the player is currently playing, else false.
+    virtual bool isBusy() = 0;
+    // call periodically from the main loop to update the object
+    virtual void update() = 0;
 };

--- a/carl/mp3_driver_dfrobot_dfplayer_mini.h
+++ b/carl/mp3_driver_dfrobot_dfplayer_mini.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2021 Jan Delgado <jdelgado[at]gmx.net>
+// https://github.com/jandelgado/carl
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#pragma once
+
+#ifdef USE_DFROBOT_MP3_DRIVER
+
+#include <DFRobotDFPlayerMini.h>
+#include "mp3_driver.h"  // NOLINT
+
+// implementation of the Mp3Driver module for the DFRobot library
+// https://github.com/DFRobot/DFRobotDFPlayerMini
+class Mp3DriverDfRobotDfPlayerMini : public Mp3Driver {
+    DFRobotDFPlayerMini df_player_;
+    uint8_t busy_pin_;
+
+ public:
+    // The DFPlayer module can be connected to anything satisfying the Stream
+    // interface.  Since common base class of serial ports Stream does not
+    // have the begin(baud_rate) method, we us a templated ctor here so we call
+    // the begin() method of the provided serial port here, regardless of actual
+    // type. This way, we keep everythng together and don't forget
+    // initialization.
+    template <class T>
+    Mp3DriverDfRobotDfPlayerMini(T* serial, uint8_t busy_pin)
+        : busy_pin_(busy_pin) {
+        serial->begin(9600);
+        pinMode(busy_pin_, INPUT);
+        df_player_.begin(*serial, true, false);
+        df_player_.outputDevice(DFPLAYER_DEVICE_SD);
+    }
+
+    virtual void start() { df_player_.play(); }
+
+    virtual void pause() { df_player_.pause(); }
+
+    virtual void stop() { df_player_.stop(); }
+
+    virtual void playSongFromFolder(uint8_t folder, uint16_t song) {
+        df_player_.playLargeFolder(folder, song);
+    }
+
+    virtual void setVolume(uint8_t volume) { df_player_.volume(volume); }
+
+    virtual uint8_t getMaxVolume() const { return 31; }
+
+    virtual void setEqMode(uint8_t mode) { df_player_.EQ(mode); }
+
+    virtual uint8_t getNumEqModes() const {
+        // DfPlayerMini has 6 different EQ modes
+        return 6;
+    }
+
+    virtual int16_t getFileCountInFolder(uint8_t folder) {
+        return df_player_.readFileCountsInFolder(folder);
+    }
+
+    virtual bool isBusy() { return digitalRead(busy_pin_) == LOW; }
+
+    virtual void update() {
+        // nothing to be done here
+    }
+};
+
+template <class T>
+Mp3Driver* new_mp3_driver(T* serial, uint8_t busy_pin) {
+    LOG("using DFRobot driver");
+    return new Mp3DriverDfRobotDfPlayerMini(serial, busy_pin);
+}
+
+#endif

--- a/carl/mp3_driver_factory.h
+++ b/carl/mp3_driver_factory.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Jan Delgado <jdelgado[at]gmx.net>
+// https://github.com/jandelgado/carl
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// Instanciate the Mp3Driver to be used. Will either be the Makuna, DFRobot or
+// the PowerBroker driver.  Decision is made at compile time by #define'ing
+// one of:
+//  * USE_MAKUNA_MP3_DRIVER
+//  * USE_DFROBOT_MP3_DRIVER
+//  * USE_POWERBROKER_MP3_DRIVER
+//
+#pragma once
+#include "mp3_driver.h"
+
+#if !defined(USE_MAKUNA_MP3_DRIVER) &&  \
+    !defined(USE_DFROBOT_MP3_DRIVER) && \
+    !defined(USE_POWERBROKER_MP3_DRIVER)
+
+#warning neither USE_MAKUNA_MP3_DRIVER, USE_POWERBROKER_MP3_DRIVER, \
+         USE_DFROBOT_MP3_DRIVER set, defaulting to USE_MAKUNA_MP3_DRIVER
+
+// uncomment driver to use in case none is set. Don't forget to install
+// the needed lib!
+#define USE_MAKUNA_MP3_DRIVER
+// #define USE_DFROBOT_MP3_DRIVER
+// #define USE_POWERBROKER_MP3_DRIVER
+
+#endif
+
+#if defined(USE_MAKUNA_MP3_DRIVER)
+// depends on: "DFPlayer Mini Mp3 by Makuna" (#1561)
+#include "mp3_driver_makuna_dfplayer_mini.h"
+
+#elif defined(USE_POWERBROKER_MP3_DRIVER)
+// depends on: "DFPlayerMini_Fast" (#6851), "FireTimer" (#7000)
+#include "mp3_driver_powerbroker_dfplayer_mini.h"
+
+#elif defined(USE_DFROBOT_MP3_DRIVER)
+// depends on: "DFRobotDFPlayerMini" (#1308)
+#include "mp3_driver_dfrobot_dfplayer_mini.h"
+
+#else
+#error "unknown MP3 driver configured."
+#endif

--- a/carl/mp3_driver_makuna_dfplayer_mini.h
+++ b/carl/mp3_driver_makuna_dfplayer_mini.h
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 Jan Delgado <jdelgado[at]gmx.net>
+// https://github.com/jandelgado/carl
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#pragma once
+
+#ifdef USE_MAKUNA_MP3_DRIVER
+
+#include <DFMiniMp3.h>
+#include <log4arduino.h>
+#include "mp3_driver.h"  // NOLINT
+
+// implementation of the Mp3Driver module for the Makuna DfMiniMp3 library
+// https://github.com/Makuna/DFMiniMp3
+class Mp3DriverMakunaDfPlayerMini : public Mp3Driver {
+    class Mp3Notify;
+    typedef DFMiniMp3<SoftwareSerial, Mp3Notify> DfMp3;
+    DfMp3 df_player_;
+    uint8_t busy_pin_;
+
+    // implement a notification class, its member methods will get called
+    class Mp3Notify {
+     public:
+        static void PrintlnSourceAction(DfMp3_PlaySources source,
+                                        const char* action) {
+            if (source & DfMp3_PlaySources_Sd) {
+                Serial.print("SD Card, ");
+            }
+            if (source & DfMp3_PlaySources_Usb) {
+                Serial.print("USB Disk, ");
+            }
+            if (source & DfMp3_PlaySources_Flash) {
+                Serial.print("Flash, ");
+            }
+            Serial.println(action);
+            LOG("makuna: source=%d action=%s", source, action);
+        }
+        static void OnError(uint16_t errorCode) {
+            // see DfMp3_Error for code meaning
+            Serial.println();
+            Serial.print("Com Error ");
+            Serial.println(errorCode);
+            LOG("makuna: com error %d", errorCode);
+        }
+        static void OnPlayFinished(DfMp3_PlaySources source, uint16_t track) {
+            Serial.print("Play finished for #");
+            Serial.println(track);
+            LOG("makuna: play finished for %d", track);
+        }
+        static void OnPlaySourceOnline(DfMp3_PlaySources source) {
+            PrintlnSourceAction(source, "online");
+        }
+        static void OnPlaySourceInserted(DfMp3_PlaySources source) {
+            PrintlnSourceAction(source, "inserted");
+        }
+        static void OnPlaySourceRemoved(DfMp3_PlaySources source) {
+            PrintlnSourceAction(source, "removed");
+        }
+    };
+
+ public:
+    // The DFPlayer module can be connected to anything satisfying the Stream
+    // interface, e.g. SoftwareSerial as well as HardwareSerial
+    template <class T>
+    Mp3DriverMakunaDfPlayerMini(T* serial, uint8_t busy_pin)
+        : df_player_(DfMp3(*serial)), busy_pin_(busy_pin) {
+        pinMode(busy_pin_, INPUT);
+        df_player_.begin();
+        df_player_.setPlaybackSource(DfMp3_PlaySource::DfMp3_PlaySource_Sd);
+    }
+
+    virtual void start() { df_player_.start(); }
+
+    virtual void pause() { df_player_.pause(); }
+
+    virtual void stop() { df_player_.stop(); }
+
+    virtual void playSongFromFolder(uint8_t folder, uint16_t song) {
+        df_player_.playFolderTrack16(folder, song);
+    }
+
+    virtual void setVolume(uint8_t volume) { df_player_.setVolume(volume); }
+
+    virtual uint8_t getMaxVolume() const { return 30; }
+
+    virtual void setEqMode(uint8_t mode) {
+        df_player_.setEq(static_cast<DfMp3_Eq>(mode));
+    }
+
+    virtual uint8_t getNumEqModes() const {
+        // DfPlayerMini has 6 different EQ modes
+        return 6;
+    }
+
+    virtual int16_t getFileCountInFolder(uint8_t folder) {
+        return df_player_.getFolderTrackCount(folder);
+    }
+
+    virtual bool isBusy() { return digitalRead(busy_pin_) == LOW; }
+
+    virtual void update() { df_player_.loop(); }
+};
+
+template <class T>
+Mp3Driver* new_mp3_driver(T* serial, uint8_t busy_pin) {
+    LOG("using Makuna driver");
+    return new Mp3DriverMakunaDfPlayerMini(serial, busy_pin);
+}
+#endif

--- a/carl/mp3_driver_powerbroker_dfplayer_mini.h
+++ b/carl/mp3_driver_powerbroker_dfplayer_mini.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 Jan Delgado <jdelgado[at]gmx.net>
+// https://github.com/jandelgado/carl
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#pragma once
+
+#ifdef USE_POWERBROKER_MP3_DRIVER
+
+#include <DFPlayerMini_Fast.h>
+#include "mp3_driver.h"  // NOLINT
+#include <log4arduino.h>
+
+// implementation of the Mp3Driver module for the DFRobot library
+// https://github.com/DFRobot/DFRobotDFPlayerMini
+class Mp3DriverPowerBrokerDfPlayerMini : public Mp3Driver {
+    DFPlayerMini_Fast df_player_;
+    uint8_t busy_pin_;
+    constexpr auto static kCommTimeoutMs = 500;
+    constexpr auto static kDfDebug = false;
+
+ public:
+    // The DFPlayer module can be connected to anything satisfying the Stream
+    // interface.  Since common base class of serial ports Stream does not
+    // have the begin(baud_rate) method, we us a templated ctor here so we call
+    // the begin() method of the provided serial port here, regardless of actual
+    // type. This way, we keep everythng together and don't forget
+    // initialization.
+    template <class T>
+    Mp3DriverPowerBrokerDfPlayerMini(T* serial, uint8_t busy_pin)
+        : busy_pin_(busy_pin) {
+        serial->begin(9600);
+        pinMode(busy_pin_, INPUT);
+        df_player_.begin(*serial, kDfDebug, kCommTimeoutMs);
+        df_player_.playbackSource(dfplayer::TF);    // TF = SD Card
+    }
+
+    virtual void start() { df_player_.resume(); }
+
+    virtual void pause() { df_player_.pause(); }
+
+    virtual void stop() { df_player_.stop(); }
+
+    virtual void playSongFromFolder(uint8_t folder, uint16_t song) {
+        df_player_.playLargeFolder(folder, song);
+    }
+
+    virtual void setVolume(uint8_t volume) { df_player_.volume(volume); }
+
+    virtual uint8_t getMaxVolume() const { return 31; }
+
+    virtual void setEqMode(uint8_t mode) { df_player_.EQSelect(mode); }
+
+    virtual uint8_t getNumEqModes() const {
+        // DfPlayerMini has 6 different EQ modes
+        return 6;
+    }
+
+    virtual int16_t getFileCountInFolder(uint8_t folder) {
+        return df_player_.numTracksInFolder(folder);
+    }
+
+    virtual bool isBusy() { return digitalRead(busy_pin_) == LOW; }
+
+    virtual void update() {
+        // nothing to be done here
+    }
+};
+
+template <class T>
+Mp3Driver* new_mp3_driver(T* serial, uint8_t busy_pin) {
+    LOG("using PowerBroker driver");
+    return new Mp3DriverPowerBrokerDfPlayerMini(serial, busy_pin);
+}
+
+#endif

--- a/carl/mp3module.h
+++ b/carl/mp3module.h
@@ -19,156 +19,156 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
-#ifndef MP3MODULE_H_
-#define MP3MODULE_H_
-
-#include <DFRobotDFPlayerMini.h>
+#pragma once
 #include "log.h"
+#include "mp3_driver.h"
 
 /*
  * Frontend to the DFPlayerMini module
  */
 class Mp3Module {
  private:
-  enum class eEvent { NONE, PLAYPAUSE, STOP, NEXT, PREV, PLAY_SONG };
+    enum class eEvent { NONE, PLAYPAUSE, STOP, NEXT, PREV, PLAY_SONG };
+    // how often to retry to read a folders
+    constexpr static auto kMaxFolderReadTries = 3;
 
  public:
-  enum class ePlayMode { REPEAT, PLAY_ONCE, SINGLE_SONG };
+    enum class ePlayMode { REPEAT, PLAY_ONCE, SINGLE_SONG };
 
-  struct SongInfo {
-    SongInfo(bool found, uint8_t folder, uint16_t song)
-        : found_(found), folder_(folder), song_(song) {}
-    bool found_;
-    uint8_t folder_;
-    uint16_t song_;
-  };
+    struct SongInfo {
+        SongInfo(bool found, uint8_t folder, uint16_t song)
+            : found_(found), folder_(folder), song_(song) {}
+        bool found_;
+        uint8_t folder_;
+        uint16_t song_;
+    };
 
-  Mp3Module() = delete;
+    Mp3Module() = delete;
 
-  // The DFPlayer module can be connected to anything satisfying the Stream
-  // interface.  Since common base class of serial ports Stream does not
-  // have the begin(baud_rate) method, we us a templated ctor here so we call
-  // the begin() method of the provided serial port here, regardless of actual
-  // type. This way, we keep everythng together and don't forget initialization.
-  template <class T>
-  Mp3Module(T* serial, uint8_t busy_pin, ePlayMode skip_mode)
-      : busy_pin_(busy_pin), skip_mode_(skip_mode) {
-    serial->begin(9600);
-    pinMode(busy_pin_, INPUT);
-    df_player_.begin(*serial, true, false);
-    df_player_.outputDevice(DFPLAYER_DEVICE_SD);
-
-    // get number of files per folder so we can later browse the folders.
-    memset(folder_count_, 0, sizeof(uint16_t) * kMaxFolders);
-    for (auto i = 0; i < kMaxFolders; i++) {
-      const auto count = df_player_.readFileCountsInFolder(i + 1);
-      LOG("  folder %d -> %d songs", i, count);
-      if (count == -1) {
-        continue;
-      }
-      folder_count_[i] = count;
+    // The DFPlayer module can be connected to anything satisfying the Stream
+    // interface.  Since common base class of serial ports Stream does not
+    // have the begin(baud_rate) method, we us a templated ctor here so we call
+    // the begin() method of the provided serial port here, regardless of actual
+    // type. This way, we keep everythng together and don't forget
+    // initialization.
+    Mp3Module(Mp3Driver* mp3_driver, ePlayMode skip_mode)
+        : mp3_driver_(mp3_driver), skip_mode_(skip_mode) {
+        // get number of files per folder so we can later browse the folders.
+        memset(folder_count_, 0, sizeof(uint16_t) * kMaxFolders);
+        for (auto i = 0; i < kMaxFolders; i++) {
+            // some module return -1 even if there are files in the folder.
+            // in this case we try to read again
+            for (auto curtry = 1; curtry <= kMaxFolderReadTries; curtry++) {
+                const auto count = mp3_driver_->getFileCountInFolder(i + 1);
+                LOG("  folder %d -> %d songs (%d/%d)", i, count, curtry,
+                    kMaxFolderReadTries);
+                if (count == -1) {
+                    delay(500);
+                    continue;
+                }
+                folder_count_[i] = count;
+                break;
+            }
+        }
+        setEqMode(eq_mode_);
     }
-    setEqMode(eq_mode_);
-  }
 
-  void setSkipMode(ePlayMode skip_mode) { skip_mode_ = skip_mode; }
+    void setSkipMode(ePlayMode skip_mode) { skip_mode_ = skip_mode; }
 
-  void setEventPlayPause() { event_ = eEvent::PLAYPAUSE; }
-  void setEventPlaySong(uint8_t folder, uint16_t song) {
-    event_ = eEvent::PLAY_SONG;
-    next_song_ = song;
-    next_folder_ = folder;
-  }
-  void setEventStop() { event_ = eEvent::STOP; }
-  void setEventPrev() { event_ = eEvent::PREV; }
-  void setEventNext() { event_ = eEvent::NEXT; }
+    void setEventPlayPause() { event_ = eEvent::PLAYPAUSE; }
+    void setEventPlaySong(uint8_t folder, uint16_t song) {
+        event_ = eEvent::PLAY_SONG;
+        next_song_ = song;
+        next_folder_ = folder;
+    }
+    void setEventStop() { event_ = eEvent::STOP; }
+    void setEventPrev() { event_ = eEvent::PREV; }
+    void setEventNext() { event_ = eEvent::NEXT; }
 
-  // update players internal state, call periodically from main loop
-  void update();
+    // update players internal state, call periodically from main loop
+    void update();
 
-  // set internal folder and song which will be played on next Play event
-  void setNextSong(uint8_t folder, uint8_t song);
+    // set internal folder and song which will be played on next Play event
+    void setNextSong(uint8_t folder, uint8_t song);
 
-  void setVolume(uint8_t volume);
+    void setVolume(uint8_t volume);
 
-  // set the EQ (0..5)
-  void setEqMode(uint8_t mode);
+    // set the EQ (0..5)
+    void setEqMode(uint8_t mode);
 
-  // cycle through eq prests
-  void nextEqMode();
+    // cycle through eq prests
+    void nextEqMode();
 
-  // returns true if the player (hardware) is currently playing, otherwise
-  // false.
-  bool isBusy() const;
+    // returns true if the player (hardware) is currently playing, otherwise
+    // false.
+    bool isBusy() const;
 
-  // randomly get a song from a folder
-  SongInfo getRandomSongFromFolder(uint8_t folder) const;
+    // randomly get a song from a folder
+    SongInfo getRandomSongFromFolder(uint8_t folder) const;
 
  private:
-  // start to play given file in folder. count starts with 1 for file and
-  // folder. Updates curFile and cur_folder_ pointers.
-  void playSongFromFolder(uint8_t folder, uint16_t song);
+    // start to play given file in folder. count starts with 1 for file and
+    // folder. Updates curFile and cur_folder_ pointers.
+    void playSongFromFolder(uint8_t folder, uint16_t song);
 
-  // song navigation
-  SongInfo getNextSong() const;
-  SongInfo getPrevSong() const;
-  SongInfo getCurSong() const {
-    return SongInfo(getNumSongs(cur_folder_) > 0, cur_folder_, cur_song_);
-  }
-  int getNumSongs(uint8_t folder) const { return folder_count_[folder]; }
+    // song navigation
+    SongInfo getNextSong() const;
+    SongInfo getPrevSong() const;
+    SongInfo getCurSong() const {
+        return SongInfo(getNumSongs(cur_folder_) > 0, cur_folder_, cur_song_);
+    }
+    int getNumSongs(uint8_t folder) const { return folder_count_[folder]; }
 
-  // returns true if the player is playing for at least timespan ms
-  bool isCurSongPlayingSince(uint32_t kTimespan) const;
+    // returns true if the player is playing for at least timespan ms
+    bool isCurSongPlayingSince(uint32_t kTimespan) const;
 
  private:
-  enum class eState {
-    PAUSED,
-    STOPPED,
-    START_PLAYING,
-    WAIT_FOR_PLAYER_TO_START,
-    PLAYING,
-  };
+    enum class eState {
+        PAUSED,
+        STOPPED,
+        START_PLAYING,
+        WAIT_FOR_PLAYER_TO_START,
+        PLAYING,
+    };
 
-  eEvent consumeEvent() {
-    auto e = event_;
-    event_ = eEvent::NONE;
-    return e;
-  }
+    eEvent consumeEvent() {
+        auto e = event_;
+        event_ = eEvent::NONE;
+        return e;
+    }
 
-  // CONFIG: if PREV is pressed and the current song plays less then
-  // kJumpPrevThresh ms, then jump to the previous song, else restart current
-  // song.
-  static auto constexpr kJumpPrevThresh = 3000;
-  static auto constexpr kTimeoutStartPlayingMs = 1000;
+    // CONFIG: if PREV is pressed and the current song plays less then
+    // kJumpPrevThresh ms, then jump to the previous song, else restart current
+    // song.
+    static auto constexpr kJumpPrevThresh = 3000;
+    static auto constexpr kTimeoutStartPlayingMs = 1000;
 
-  // CONFIG: index (starting with 0) of first and last folder containing
-  // playlists (corresponds to folders 01/ .. 09/ on SD card)
-  static auto constexpr kFirstFolder = 0;
-  static auto constexpr kLastFolder = 8;
+    // CONFIG: index (starting with 0) of first and last folder containing
+    // playlists (corresponds to folders 01/ .. 09/ on SD card)
+    static auto constexpr kFirstFolder = 0;
+    static auto constexpr kLastFolder = 8;
 
-  // max number of supported folders. Carl suports 9 folders which can be
-  // directly accessed with the folder buttons plus 1 folder for the startup
-  // jingles.
-  static auto constexpr kMaxFolders = (kLastFolder - kFirstFolder + 1) + 1;
+    // max number of supported folders. Carl suports 9 folders which can be
+    // directly accessed with the folder buttons plus 1 folder for the startup
+    // jingles.
+    static auto constexpr kMaxFolders = (kLastFolder - kFirstFolder + 1) + 1;
 
-  DFRobotDFPlayerMini df_player_;
-  eState state_ = eState::STOPPED;
-  eEvent event_ = eEvent::NONE;
-  const uint8_t busy_pin_;
-  ePlayMode skip_mode_;
+    Mp3Driver* mp3_driver_;
 
-  //  uint32_t idle_since_ = 0;
-  uint32_t song_playing_since_ = 0;
-  uint32_t time_start_playing_ = 0;
+    eState state_ = eState::STOPPED;
+    eEvent event_ = eEvent::NONE;
+    ePlayMode skip_mode_;
 
-  uint8_t cur_folder_ = 0;  // current folder. Indexing starts with 0.
-  uint16_t cur_song_ = 0;   // current song. Indexing starts with 0.
+    //  uint32_t idle_since_ = 0;
+    uint32_t song_playing_since_ = 0;
+    uint32_t time_start_playing_ = 0;
 
-  uint8_t next_folder_ = 0;
-  uint8_t next_song_ = 0;
+    uint8_t cur_folder_ = 0;  // current folder. Indexing starts with 0.
+    uint16_t cur_song_ = 0;   // current song. Indexing starts with 0.
 
-  uint16_t folder_count_[kMaxFolders];
-  uint8_t eq_mode_ = 5;
+    uint8_t next_folder_ = 0;
+    uint8_t next_song_ = 0;
+
+    uint16_t folder_count_[kMaxFolders];
+    uint8_t eq_mode_ = 5;
 };
-
-#endif  // MP3MODULE_H_

--- a/carl/platformio.ini
+++ b/carl/platformio.ini
@@ -2,15 +2,44 @@
 
 [platformio]
 src_dir = .
+default_envs = pro16MHzatmega328-powerbroker
 
-[env:pro16MHzatmega328]
+; You MUST inject these options into [env:] section
+; using ${common_env_data.***} (see below)
+[common_env_data]
+lib_deps = jled@4.7.0
+           log4arduino@1.0.0
+           https://github.com/dxinteractive/AnalogMultiButton#1.0.1
+
+[env:pro16MHzatmega328-powerbroker]
 platform = atmelavr
 board = pro16MHzatmega328
 framework = arduino
 # uncomment to disable logging to serial console
 #build_flags=-DNO_LOGGING
+build_flags=-DUSE_POWERBROKER_MP3_DRIVER
+#lib_deps = DFPlayerMini_Fast
+#           ${common_env_data.lib_deps}
+lib_deps = https://github.com/jandelgado/DFPlayerMini_Fast#2a3fb1324077d4475a692d7b9b98d6cdb41392b7
+           ${common_env_data.lib_deps}
+
+[env:pro16MHzatmega328-makuna]
+platform = atmelavr
+board = pro16MHzatmega328
+framework = arduino
+# uncomment to disable logging to serial console
+#build_flags=-DNO_LOGGING
+build_flags=-DUSE_MAKUNA_MP3_DRIVER
+lib_deps = https://github.com/Makuna/DFMiniMp3#1.0.7
+           ${common_env_data.lib_deps}
+
+[env:pro16MHzatmega328-dfrobot]
+platform = atmelavr
+board = pro16MHzatmega328
+framework = arduino
+# uncomment to disable logging to serial console
+#build_flags=-DNO_LOGGING
+build_flags=-DUSE_DFROBOT_MP3_DRIVER
 lib_deps = https://github.com/DFRobot/DFRobotDFPlayerMini#1.0.5
-           jled@4.7.0
-           log4arduino@1.0.0
-           https://github.com/dxinteractive/AnalogMultiButton#1.0.1
+           ${common_env_data.lib_deps}
 

--- a/carl/player.h
+++ b/carl/player.h
@@ -19,9 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
-#ifndef PLAYER_H_
-#define PLAYER_H_
-
+#pragma once
 #include <Arduino.h>
 #include <jled.h>
 #include "keypad.h"     // NOLINT
@@ -66,5 +64,3 @@ class Player {
   uint8_t last_volume_ = 0;
   uint32_t start_time_jingle_;
 };
-
-#endif  // PLAYER_H_


### PR DESCRIPTION
* access dfplayer mini through an interface class (class Mp3Driver), instead of directly calling the DFRobot library. This allows for easy swap-out of library implementations during compile-time (mp3_driver_factory.h)
  * add additional library: https://github.com/PowerBroker2/DFPlayerMini_Fast
  * add additional library: https://github.com/Makuna/DFMiniMp3
* make access reading of SD card folder count resilient, retrying on errors.