### PR TITLE
large folder play api now opt-in

### DIFF
--- a/carl/mp3_driver.h
+++ b/carl/mp3_driver.h
@@ -32,8 +32,10 @@ class Mp3Driver {
     virtual void pause() = 0;
     // stop playback
     virtual void stop() = 0;
-    // play song from given folder.
-    virtual void playSongFromFolder(uint8_t folder, uint16_t song) = 0;
+    // play song from given folder, where files are named ##/###*.mp3
+    virtual void playSongFromFolder(uint8_t folder, uint8_t  song) = 0;
+    // play song from given large folder, where files are named ##/####*.mp3
+    virtual void playSongFromLargeFolder(uint8_t folder, uint16_t song) = 0;
     // return maximum allowed volume
     virtual uint8_t getMaxVolume() const = 0;
     // set volume. volume is in range [0..getMaxVolume()]

--- a/carl/mp3_driver_dfrobot_dfplayer_mini.h
+++ b/carl/mp3_driver_dfrobot_dfplayer_mini.h
@@ -54,7 +54,11 @@ class Mp3DriverDfRobotDfPlayerMini : public Mp3Driver {
 
     void stop() override { df_player_.stop(); }
 
-    void playSongFromFolder(uint8_t folder, uint16_t song) override {
+    void playSongFromFolder(uint8_t folder, uint8_t song) override {
+        df_player_.playFolder(folder, song);
+    }
+
+    void playSongFromLargeFolder(uint8_t folder, uint16_t song) override {
         df_player_.playLargeFolder(folder, song);
     }
 

--- a/carl/mp3_driver_makuna_dfplayer_mini.h
+++ b/carl/mp3_driver_makuna_dfplayer_mini.h
@@ -94,7 +94,11 @@ class Mp3DriverMakunaDfPlayerMini : public Mp3Driver {
 
     void stop() override { df_player_.stop(); }
 
-    void playSongFromFolder(uint8_t folder, uint16_t song) override {
+    void playSongFromFolder(uint8_t folder, uint8_t song) override {
+        df_player_.playFolderTrack(folder, song);
+    }
+
+    void playSongFromLargeFolder(uint8_t folder, uint16_t song) override {
         df_player_.playFolderTrack16(folder, song);
     }
 

--- a/carl/mp3_driver_powerbroker_dfplayer_mini.h
+++ b/carl/mp3_driver_powerbroker_dfplayer_mini.h
@@ -57,7 +57,11 @@ class Mp3DriverPowerBrokerDfPlayerMini : public Mp3Driver {
 
     void stop() override { df_player_.stop(); }
 
-    void playSongFromFolder(uint8_t folder, uint16_t song) override {
+    void playSongFromFolder(uint8_t folder, uint8_t song) override {
+        df_player_.playFolder(folder, song);
+    }
+
+    void playSongFromLargeFolder(uint8_t folder, uint16_t song) override {
         df_player_.playLargeFolder(folder, song);
     }
 

--- a/carl/mp3module.cpp
+++ b/carl/mp3module.cpp
@@ -21,8 +21,16 @@
 //
 #include "mp3module.h"  // NOLINT
 
+// uncomment to use large folder DFPlayer API with up to 3000 mp3s in a folder.
+// files are named "##/####*.mp3" then. Does not work with all DFPlayers.
+// #define USE_LARGE_FOLDERS
+
 Mp3Module::Mp3Module(Mp3Driver* mp3_driver, ePlayMode skip_mode)
     : mp3_driver_(mp3_driver), skip_mode_(skip_mode) {
+#ifdef USE_LARGE_FOLDERS
+    LOG("m using large folders");
+#endif
+    LOG("m scanning folders...");
     // get number of files per folder so we can later browse the folders.
     memset(folder_count_, 0, sizeof(uint16_t) * kMaxFolders);
     for (auto i = 0; i < kMaxFolders; i++) {
@@ -212,7 +220,11 @@ void Mp3Module::playSongFromFolder(uint8_t folder, uint16_t song) {
     LOG("play s=%d, f=%d (n=%d)", song, folder, folder_count_[folder]);
     cur_folder_ = folder;
     cur_song_ = song;
-    mp3_driver_->playSongFromFolder(folder + 1, song + 1);
+#ifdef USE_LARGE_FOLDERS
+    mp3_driver_->playSongFromLargeFolder(folder + 1, song + 1);
+#else
+    mp3_driver_->playSongFromFolder(folder + 1, static_cast<uint8_t>(song + 1));
+#endif
 }
 
 // Randomly select a song from the given folder


### PR DESCRIPTION
to use the large folder play api, which allows up to 3000 files, `#define USE_LARGE_FOLDERS` (see `mp3module.cpp`).

changed because of problems with certain DfPlayerMini modules