### PR TITLE
disable large folder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ in [platform.ini](carl/platform.ini). The following options can be configured:
 |---------------------------|------------------------------|-------------------------------------|
 | Disable logging           | `NO_LOGGING`                 | unset, i.e. logging is enabled      |
 | Enable configuration mode | `ENABLE_CONFIG_MODE`         | unset, i.e. config mode is disabled |
-| Support large folders     | `USE_LARGE_FOLDERS`          | enabled                             |
+| Support large folders     | `USE_LARGE_FOLDERS`          | disabled                            |
 | Use PowerBroker's driver  | `USE_POWERBROKER_MP3_DRIVER` | this is the default                 |
 | Use Makunas's driver      | `USE_MAKUNA_MP3_DRIVER`      |                                     |
 | Use DFRobot's driver      | `USE_DFROBOT_MP3_DRIVER`     |                                     |

--- a/carl/config.h
+++ b/carl/config.h
@@ -24,8 +24,8 @@
 
 // uncomment to use large folder DFPlayer API with up to 3000 mp3s in a folder.
 // files are named "##/####*.mp3" then. Does not work with all DFPlayers,
-// otherwise files are named "##/###*.mp3".
-#define USE_LARGE_FOLDER
+// otherwise files are named "##/###*.mp3", with only up to 255 file per folder.
+// #define USE_LARGE_FOLDERS
 
 // uncomment to disable logging
 // #define NO_LOGGING

--- a/carl/platformio.ini
+++ b/carl/platformio.ini
@@ -5,13 +5,14 @@ src_dir = .
 default_envs = pro16MHzatmega328-powerbroker
 
 [common_env_data]
-;build_flags=
+
+build_flags=
 
 # uncomment to disable logging to serial console
 # build_flags=-DNO_LOGGING
 
 # use large folders. remember to use ####*.mp3 scheme file names then.
-build_flags=-DUSE_LARGE_FOLDERS -DENABLE_CONFIG_MODE
+# build_flags=-DUSE_LARGE_FOLDERS -DENABLE_CONFIG_MODE
 lib_deps = jled@4.7.0
            log4arduino@1.0.0
            https://github.com/dxinteractive/AnalogMultiButton#1.0.1


### PR DESCRIPTION
* large folders are now opt-in (enable in `config.h`)
* sd card filenames are `##/###*.mp3` 
