### PR TITLE
GD3200B quirks mode added

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@ follow shortly.
 Carl is featured in the german edition of the Make Magazine in August 2021:
 
 <p float="left">
-  <img src=".images/make_04_21.jpg" height=300>
-  <img src=".images/carl.jpg" height=300 alt="carl music box">
+<img src=".images/make_04_21.jpg" height=300>
+<img src=".images/carl.jpg" height=300 alt="carl music box">
 </p>
 
 <!-- vim-markdown-toc GFM -->
 
 * [Hardware](#hardware)
-    * [DFPlayerMini Modules](#dfplayermini-modules)
+    * [Note on DFPlayer Mini Modules](#note-on-dfplayer-mini-modules)
 * [Build the firmware](#build-the-firmware)
     * [Configuration](#configuration)
+        * [DFPlayer driver library selection](#dfplayer-driver-library-selection)
+        * [GD3200B Quirks mode](#gd3200b-quirks-mode)
     * [Arduino IDE](#arduino-ide)
     * [PlatformIO](#platformio)
 * [References](#references)
@@ -29,24 +31,27 @@ Carl is featured in the german edition of the Make Magazine in August 2021:
 
 TODO
 
-### DFPlayerMini Modules
+### Note on DFPlayer Mini Modules
 
-During the tests of Carl, we encountered different DFPlayerMini modules, which
-turned out to behave differently. DFPlayer's with the GD3200B chip for example
-were found **not** to work with any of the available libraries.
+During the tests of Carl, we encountered different DFPlayer Mini modules, which
+turned out to behave differently. DFPlayer's with the `GD3200B` chip for example
+were found ~~ **not** to work with any of the available libraries~~ to only work
+in a quirks mode.
 
 The differences can easily be spotted and are described below.
 
-| Working                                         | Not Working                                                             |
-|---------------------------------------------------------|---------------------------------------------------------------------------------|
-| 24 pins, labelled `AA20HFJ648-94`                       | 16 pins, labelled `GD3200B`                                                     |
+| Working                                                 | ~~Not Working~~ Working with Quirks                    |
+|---------------------------------------------------------|--------------------------------------------------------|
+| 24 pins, labelled `AA20HFJ648-94`                       | 16 pins, labelled `GD3200B`                            |
 | <img src=".images/dfplayer_mini_good.jpg" height="200"> | <img src=".images/dfplayer_mini_bad.jpg" height="200"> |
 
 The DFPlayerMini with the `GD3200B` failed reporting correctly the number of
-songs per folder.
+songs per folder. A Quirks mode is provided, to get these modules work with
+Carl.
 
-There are more models out there, see [this site for a testing tool and further
-information](https://github.com/ghmartin77/DFPlayerAnalyzer)
+Besides the mentioned `GD3200B` model, there are more models out there which
+may be incompatible, see [this site for a testing tool and further
+information](https://github.com/ghmartin77/DFPlayerAnalyzer).
 
 ## Build the firmware
 
@@ -55,25 +60,34 @@ The firmware can be built using the Arduino IDE or PlatformIO.
 ### Configuration
 
 The firmware image can be configured either in [config.h](carl/config.h) (for Arduino IDE) or
-
 in [platform.ini](carl/platform.ini). The following options can be configured:
 
-| Option                    | `#define`                    | Default                             |
-|---------------------------|------------------------------|-------------------------------------|
-| Disable logging           | `NO_LOGGING`                 | unset, i.e. logging is enabled      |
-| Enable configuration mode | `ENABLE_CONFIG_MODE`         | unset, i.e. config mode is disabled |
-| Support large folders     | `USE_LARGE_FOLDERS`          | disabled                            |
-| Use PowerBroker's driver  | `USE_POWERBROKER_MP3_DRIVER` | this is the default                 |
-| Use Makunas's driver      | `USE_MAKUNA_MP3_DRIVER`      |                                     |
-| Use DFRobot's driver      | `USE_DFROBOT_MP3_DRIVER`     |                                     |
- 
+| Option                     | `#define`                    | Default                             |
+|----------------------------|------------------------------|-------------------------------------|
+| Disable logging            | `NO_LOGGING`                 | unset, i.e. logging is enabled      |
+| Enable configuration mode  | `ENABLE_CONFIG_MODE`         | unset, i.e. config mode is disabled |
+| Support large folders      | `USE_LARGE_FOLDERS`          | disabled                            |
+| Use PowerBroker's driver   | `USE_POWERBROKER_MP3_DRIVER` | this is the default                 |
+| Use Makunas's driver       | `USE_MAKUNA_MP3_DRIVER`      |                                     |
+| Use DFRobot's driver       | `USE_DFROBOT_MP3_DRIVER`     |                                     |
+| Enable GD3200B Quirks Mode | `GD3200B_QUIRKS`             | unset                               |
+
+#### DFPlayer driver library selection
+
 Choose one of the `USE_*_MP3_DRIVER` options. If not set, the PowerBroker
 driver will be used. When the firmware is build using platformio (i.e. using
 `make`) the required libraries are downloaded automatically.  When using the
-Arduino IDE, don't forget to install the actual libraries:
+Arduino IDE, don't forget to install the actual library used, e.g.:
 * [DFPlayerMini_Fast](https://github.com/PowerBroker2/DFPlayerMini_Fast) and [FireTimer](https://github.com/PowerBroker2/FireTimer) for `USE_POWEBROKER_MP3_DRIVER`
-* [DFMiniMp3](https://github.com/Makuna/DFMiniMp3) for `USE_MAKUNA_MP3_DRIVER`
-* [DFRobotPlayerMini](https://github.com/DFRobot/DFRobotDFPlayerMini) for `USE_DFROBOT_MP3_DRIVER` 
+* [DFMiniMp3](https://github.com/Makuna/DFMiniMp3) for `USE_MAKUNA_MP3_DRIVER` (recommended for GD3200B models)
+* [DFRobotPlayerMini](https://github.com/DFRobot/DFRobotDFPlayerMini) for `USE_DFROBOT_MP3_DRIVER`
+
+#### GD3200B Quirks mode
+
+When using `GD3200B` based DFPlayer modules, the `GD3200B_QUIRKS` `#define` has
+to be set in order to circumvent some incompatibilities (bugs?) these devices
+have.  I successfully tested a `GD3200B` DFPlayer using the Makuna-Driver
+(`USE_MAKUNA_MP3_DRIVER`) and the quirks mode enabled.
 
 ### Arduino IDE
 
@@ -85,13 +99,13 @@ Select `Arduino Pro or Pro Mini` as the target board under `Tools` > `Board` >
 
 Install the needed libraries using `Sketch` > `Include Library` > `Manage Libraries...`:
 * AnalogMultiButton (1.0.0)
-* DFPlayerMini_Fast (1.2.4)
-* JLed (4.7.0)
-* log4arduino (1.0.0)
+* DFPlayerMini_Fast (1.2.4) (Powerbroker DFPlayer Library)
+* JLed (4.8.0)
+* log4arduino (1.1.0)
 
 Alternatively, install the libraries with this command:
 ```
-arduino --install-library JLed:4.7.0,log4arduino:1.0.0,AnalogMultiButton:1.0.0,DFPlayerMini_Fast:1.2.4,FireTimer:1.0.5
+arduino --install-library JLed:4.9.0,log4arduino:1.1.0,AnalogMultiButton:1.0.0,DFPlayerMini_Fast:1.2.4,FireTimer:1.0.5
 ```
 
 Compile and upload the sketch using the corresponding commands in the Arduino
@@ -123,4 +137,5 @@ the Arduino IDE, the PowerBroker2 driver is used by default.
 
 ## Author
 
-(C) Copyright 2021 by Jan Delgado.
+(C) Copyright 2021-2022 by Jan Delgado.
+

--- a/README.md
+++ b/README.md
@@ -87,7 +87,15 @@ Arduino IDE, don't forget to install the actual library used, e.g.:
 When using `GD3200B` based DFPlayer modules, the `GD3200B_QUIRKS` `#define` has
 to be set in order to circumvent some incompatibilities (bugs?) these devices
 have.  I successfully tested a `GD3200B` DFPlayer using the Makuna-Driver
-(`USE_MAKUNA_MP3_DRIVER`) and the quirks mode enabled.
+(`USE_MAKUNA_MP3_DRIVER`) and the quirks mode enabled. Check the log output
+to make sure that the `GD3200B` quirks mode is enabled on startup:
+
+```
+0(1412): carl starting.
+0(1379): using Makuna driver
+61(1321): m scanning folders...
+62(1319): m enabling GD3200B quirks mode
+```
 
 ### Arduino IDE
 
@@ -127,6 +135,7 @@ the Arduino IDE, the PowerBroker2 driver is used by default.
 
 ## References
 
+* [DFRobot DFPlayer Mini]()
 * [Carl testdata generator](https://github.com/jandelgado/carl-testdata/)
 * [DFRobot DFRobotDFPlayerMini Library](https://github.com/DFRobot/DFRobotDFPlayerMini)
 * [Makuna DFMiniMp3 Library](https://github.com/Makuna/DFMiniMp3)
@@ -134,6 +143,7 @@ the Arduino IDE, the PowerBroker2 driver is used by default.
 * [JLed](https://github.com/jandelgado/jled)
 * [log4arduino](https://github.com/jandelgado/log4arduino)
 * [DFPlayer Analyzer](https://github.com/ghmartin77/DFPlayerAnalyzer)
+* [GD3200 information](https://discourse.voss.earth/t/dfplayer-verschiedene-versionen/681/178)
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Select `Arduino Pro or Pro Mini` as the target board under `Tools` > `Board` >
 Install the needed libraries using `Sketch` > `Include Library` > `Manage Libraries...`:
 * AnalogMultiButton (1.0.0)
 * DFPlayerMini_Fast (1.2.4) (Powerbroker DFPlayer Library)
-* JLed (4.8.0)
+* JLed (4.9.0)
 * log4arduino (1.1.0)
 
 Alternatively, install the libraries with this command:

--- a/carl/mp3_driver.h
+++ b/carl/mp3_driver.h
@@ -50,4 +50,7 @@ class Mp3Driver {
     virtual bool isBusy() = 0;
     // call periodically from the main loop to update the object
     virtual void update() = 0;
+    // reset the player
+    virtual void reset() = 0;
+    
 };

--- a/carl/mp3_driver.h
+++ b/carl/mp3_driver.h
@@ -33,7 +33,7 @@ class Mp3Driver {
     // stop playback
     virtual void stop() = 0;
     // play song from given folder, where files are named ##/###*.mp3
-    virtual void playSongFromFolder(uint8_t folder, uint8_t  song) = 0;
+    virtual void playSongFromFolder(uint8_t folder, uint8_t song) = 0;
     // play song from given large folder, where files are named ##/####*.mp3
     virtual void playSongFromLargeFolder(uint8_t folder, uint16_t song) = 0;
     // return maximum allowed volume
@@ -52,5 +52,4 @@ class Mp3Driver {
     virtual void update() = 0;
     // reset the player
     virtual void reset() = 0;
-    
 };

--- a/carl/mp3_driver_dfrobot_dfplayer_mini.h
+++ b/carl/mp3_driver_dfrobot_dfplayer_mini.h
@@ -82,6 +82,8 @@ class Mp3DriverDfRobotDfPlayerMini : public Mp3Driver {
     void update() override {
         // nothing to be done here
     }
+
+    void reset() override { df_player_.reset(); }
 };
 
 template <class T>

--- a/carl/mp3_driver_makuna_dfplayer_mini.h
+++ b/carl/mp3_driver_makuna_dfplayer_mini.h
@@ -84,6 +84,9 @@ class Mp3DriverMakunaDfPlayerMini : public Mp3Driver {
         // PIN is low active. By using INPUT_PULLUP isBusy() will return
         // false if the busy_pin GPIO is not correctly connected.
         pinMode(busy_pin_, INPUT_PULLUP);
+#ifdef GD3200B_QUIRKS
+        delay(1000);
+#endif
         df_player_.begin();
         df_player_.setPlaybackSource(DfMp3_PlaySource::DfMp3_PlaySource_Sd);
     }

--- a/carl/mp3_driver_makuna_dfplayer_mini.h
+++ b/carl/mp3_driver_makuna_dfplayer_mini.h
@@ -84,9 +84,6 @@ class Mp3DriverMakunaDfPlayerMini : public Mp3Driver {
         // PIN is low active. By using INPUT_PULLUP isBusy() will return
         // false if the busy_pin GPIO is not correctly connected.
         pinMode(busy_pin_, INPUT_PULLUP);
-#ifdef GD3200B_QUIRKS
-        delay(1000);
-#endif
         df_player_.begin();
         df_player_.setPlaybackSource(DfMp3_PlaySource::DfMp3_PlaySource_Sd);
     }
@@ -125,6 +122,8 @@ class Mp3DriverMakunaDfPlayerMini : public Mp3Driver {
     bool isBusy() override { return digitalRead(busy_pin_) == LOW; }
 
     void update() override { df_player_.loop(); }
+
+    void reset() override { df_player_.reset(); }
 };
 
 template <class T>

--- a/carl/mp3_driver_powerbroker_dfplayer_mini.h
+++ b/carl/mp3_driver_powerbroker_dfplayer_mini.h
@@ -85,6 +85,8 @@ class Mp3DriverPowerBrokerDfPlayerMini : public Mp3Driver {
     void update() override {
         // nothing to be done here
     }
+
+    void reset() override { df_player_.reset(); }
 };
 
 template <class T>

--- a/carl/mp3module.cpp
+++ b/carl/mp3module.cpp
@@ -28,7 +28,7 @@ Mp3Module::Mp3Module(Mp3Driver* mp3_driver, ePlayMode skip_mode)
     LOG("m using large folders");
 #endif
     LOG("m scanning folders...");
-   
+
 #ifdef GD3200B_QUIRKS
     LOG("m enabling GD3200B quirks mode");
     // mute since we need to play songs in order to get the file counts below
@@ -44,7 +44,7 @@ Mp3Module::Mp3Module(Mp3Driver* mp3_driver, ePlayMode skip_mode)
         // this is needed for the GD3200B since otherwise getFileCountInFolder
         // will not return correct values
         delay(100);
-        playSongFromFolder(i, 0);   // WORKAROUND to make getFileCountInFolder work
+        playSongFromFolder(i, 0);
         delay(400);
         mp3_driver_->pause();
         delay(400);

--- a/carl/mp3module.cpp
+++ b/carl/mp3module.cpp
@@ -45,7 +45,7 @@ Mp3Module::Mp3Module(Mp3Driver* mp3_driver, ePlayMode skip_mode)
 #ifdef GD3200B_QUIRKS
         // this is needed for the GD3200B since otherwise getFileCountInFolder
         // will not return correct values
-        unsigned long tmp_time = millis();
+        auto tmp_time = millis();
         delay(100);
         while (isBusy()) {
         }
@@ -266,9 +266,8 @@ Mp3Module::SongInfo Mp3Module::getRandomSongFromFolder(uint8_t folder) const {
 
 // set the players volume
 void Mp3Module::setVolume(uint8_t volume) {
-    LOG("m set vol to %d", volume);  // TODO(jd) max volume
+    LOG("m set vol to %d", volume);
     mp3_driver_->setVolume(volume);
-    delay(50);  // TODO GD3200B
 }
 
 // set the EQ mode

--- a/carl/mp3module.h
+++ b/carl/mp3module.h
@@ -116,6 +116,7 @@ class Mp3Module {
     // song.
     static auto constexpr kJumpPrevThresh = 3000;
     static auto constexpr kTimeoutStartPlayingMs = 1000;
+    static auto constexpr kTimeWaitPlayerToStart = 1000;
 
     // CONFIG: index (starting with 0) of first and last folder containing
     // playlists (corresponds to folders 01/ .. 09/ on SD card)
@@ -133,9 +134,8 @@ class Mp3Module {
     eEvent event_ = eEvent::NONE;
     ePlayMode skip_mode_;
 
-    //  uint32_t idle_since_ = 0;
-    uint32_t song_playing_since_ = 0;
-    uint32_t time_start_playing_ = 0;
+    unsigned long song_playing_since_ = 0;
+    unsigned long time_start_playing_ = 0;
 
     uint8_t cur_folder_ = 0;  // current folder. Indexing starts with 0.
     uint16_t cur_song_ = 0;   // current song. Indexing starts with 0.

--- a/carl/mp3module.h
+++ b/carl/mp3module.h
@@ -134,8 +134,8 @@ class Mp3Module {
     eEvent event_ = eEvent::NONE;
     ePlayMode skip_mode_;
 
-    unsigned long song_playing_since_ = 0;
-    unsigned long time_start_playing_ = 0;
+    uint32_t song_playing_since_ = 0;
+    uint32_t time_start_playing_ = 0;
 
     uint8_t cur_folder_ = 0;  // current folder. Indexing starts with 0.
     uint16_t cur_song_ = 0;   // current song. Indexing starts with 0.

--- a/carl/platformio.ini
+++ b/carl/platformio.ini
@@ -13,8 +13,12 @@ build_flags=
 
 # use large folders. remember to use ####*.mp3 scheme file names then.
 # build_flags=-DUSE_LARGE_FOLDERS -DENABLE_CONFIG_MODE
-lib_deps = jled@4.7.0
-           log4arduino@1.0.0
+
+# enable GD3200B quirks mode
+# build_flags=-DGD3200B_QUIRKS
+
+lib_deps = jled@4.9.0
+           log4arduino@1.1.0
            https://github.com/dxinteractive/AnalogMultiButton#1.0.1
 
 [env:pro16MHzatmega328-powerbroker]
@@ -40,5 +44,14 @@ board = pro16MHzatmega328
 framework = arduino
 build_flags=${common_env_data.build_flags} -DUSE_DFROBOT_MP3_DRIVER
 lib_deps = https://github.com/DFRobot/DFRobotDFPlayerMini#1.0.5
+           ${common_env_data.lib_deps}
+
+# build for arduino nano with GD3200B quirks mode enabled
+[env:nanoatmega328-makuna-gd3200b]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+build_flags=${common_env_data.build_flags} -DUSE_MAKUNA_MP3_DRIVER -DGD3200B_QUIRKS
+lib_deps = https://github.com/Makuna/DFMiniMp3#1.0.7
            ${common_env_data.lib_deps}
 

--- a/carl/player.cpp
+++ b/carl/player.cpp
@@ -84,7 +84,6 @@ void Player::update() {
  * a change
  */
 uint8_t Player::updateVolume() {
-
     if (millis() - last_volume_update_time_ < kVolumePollDelay) {
         return last_volume_;
     }

--- a/carl/player.h
+++ b/carl/player.h
@@ -48,6 +48,11 @@ class Player {
   static constexpr uint8_t kVolumeMax = 22;
   // config: volume of jingle
   static constexpr uint8_t kVolumeJingle = 14;
+  // time to wait in ms after the player was started before going to check
+  // the busy signal
+  static constexpr auto kTimeWaitPlayerToStart = 1000;
+  // only poll volume know every kVolumePollDelay ms
+  static constexpr auto kVolumePollDelay = 150;
 
   // read & update volume
   uint8_t updateVolume();
@@ -60,5 +65,6 @@ class Player {
   eState state_;
   eKeypadMode keypad_mode_ = eKeypadMode::PLAYLIST;
   uint8_t last_volume_ = 0;
-  uint32_t start_time_jingle_;
+  unsigned long last_volume_update_time_ = 0;
+  unsigned long start_time_jingle_;
 };

--- a/carl/player.h
+++ b/carl/player.h
@@ -65,6 +65,6 @@ class Player {
   eState state_;
   eKeypadMode keypad_mode_ = eKeypadMode::PLAYLIST;
   uint8_t last_volume_ = 0;
-  unsigned long last_volume_update_time_ = 0;
-  unsigned long start_time_jingle_;
+  uint32_t last_volume_update_time_ = 0;
+  uint32_t start_time_jingle_;
 };


### PR DESCRIPTION
The DFPlayerMini with the `GD3200B` failed reporting correctly the number of songs per folder. A Quirks mode is provided, to get these modules work with Carl.

When using `GD3200B` based DFPlayer modules, the `GD3200B_QUIRKS` `#define` has to be set in order to circumvent some incompatibilities (bugs?) these devices have.  I successfully tested a `GD3200B` DFPlayer using the Makuna-Driver
(`USE_MAKUNA_MP3_DRIVER`) and the quirks mode enabled.

